### PR TITLE
Fix hang in the case of a corrupted PNG chunk length

### DIFF
--- a/lib/apng-parser.js
+++ b/lib/apng-parser.js
@@ -9,7 +9,9 @@
 
     var readDWord = function(bytes, off) {
         var x = 0;
-        for (var i = 0; i < 4; i++) x += (bytes[i + off] << ((3 - i) * 8));
+        // Force the most-significant byte to unsigned.
+        x += ( (bytes[0 + off] << 24 ) >>> 0;
+        for (var i = 1; i < 4; i++) x += ( (bytes[i + off] << ((3 - i) * 8)) );
         return x;
     };
     var readWord = function(bytes, off) {
@@ -32,7 +34,7 @@
     };
 
     var makeDWordArray = function(x) {
-        return [(x >> 24) & 0xff, (x >> 16) & 0xff, (x >> 8) & 0xff, x & 0xff];
+        return [(x >>> 24) & 0xff, (x >>> 16) & 0xff, (x >>> 8) & 0xff, x & 0xff];
     };
     var makeStringArray = function(x) {
         var res = [];
@@ -53,16 +55,12 @@
 
     var parseChunks = function(bytes, callback) {
         var off = 8;
-        var lastOff;
         do {
-            lastOff = off;
             var length = readDWord(bytes, off);
             var type = readString(bytes, off + 4, 4);
-            if ( length <= 0 )
-                break;
             var res = callback(type, bytes, off, length);
             off += 12 + length;
-        } while(res !== false && type != "IEND" && off < bytes.length && off > lastOff);
+        } while(res !== false && type != "IEND" && off < bytes.length);
     };
 
     global.parseAPNG = function(bytes) {


### PR DESCRIPTION
If a PNG chunk has an invalid length, this can get into an endless loop and cause the tab to hang.

Verify that:
- The length is not negative ( Shouldn't be possible per PNG spec, but happens due to treating the length as signed )
- The offset never goes backwards. 

Test case PNG: http://s.andreanall.com/tmp/ball-bad.png
( That file is http://en.wikipedia.org/wiki/File:Animated_PNG_example_bouncing_beach_ball.png, with the 33rd byte changed to 0xFF )
